### PR TITLE
Fix test server

### DIFF
--- a/src/videoStream.js
+++ b/src/videoStream.js
@@ -52,7 +52,7 @@ class VideoStream extends EventEmitter {
 
     // HTTP Server to accept incomming MPEG-TS Stream from ffmpeg
     var streamServer = http.createServer( function(request, response) {
-      var params = request.url.substr(1).split('/');
+      var params = request.url.substring(1).split('/');
 
       if (params[0] !== 's1') {
         console.log(
@@ -61,7 +61,7 @@ class VideoStream extends EventEmitter {
         );
         response.end();
       }
-      response.connection.setTimeout(0);
+      response.socket.setTimeout(0);
       console.log(
         'Stream Connected: ' +
         request.socket.remoteAddress + ':' +
@@ -91,7 +91,7 @@ class VideoStream extends EventEmitter {
   }
 
   onSocketConnect(socket) {
-    let streamHeader = new Buffer(8)
+    let streamHeader = Buffer.alloc(8)
     streamHeader.write(STREAM_MAGIC_BYTES)
     streamHeader.writeUInt16BE(this.width, 4)
     streamHeader.writeUInt16BE(this.height, 6)

--- a/test/server.js
+++ b/test/server.js
@@ -3,7 +3,7 @@ const Stream = require('../src/videoStream')
 const options = {
   name: 'streamName',
   url: 'rtsp://184.72.239.149/vod/mp4:BigBuckBunny_115k.mov',
-  port: 5000
+  wsPort: 5000
 }
 
 stream = new Stream(options)


### PR DESCRIPTION
Fixed "server.js" test script, passing option "wsPort" instead of "port" previously throwing error. Refer to issue #15